### PR TITLE
(DOCSP-30565): Configure drone pipeline for `chat-server` staging

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -92,7 +92,7 @@ steps:
       chart_version: 4.12.3
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
-      release: chat-server
+      release: ${DRONE_REPO_NAME}-chat-server
       values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-staging,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=chat-server.docs.staging.corp.mongodb.com
       values_files: ["chat-server/environments/staging.yml"]
       api_server: https://api.staging.corp.mongodb.com
@@ -100,7 +100,9 @@ steps:
         from_secret: staging_kubernetes_token
 
 ---
+# --------------------
 # NOTE: not worrying about production stuff just yet
+# --------------------
 depends_on: ["test-chat-server"]
 kind: pipeline
 type: kubernetes

--- a/.drone.yml
+++ b/.drone.yml
@@ -50,6 +50,7 @@ steps:
     image: plugins/kaniko-ecr
     settings:
       dockerfile: chat-server/Dockerfile
+      context: chat-server
       create_repository: true
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
       repo: docs/${DRONE_REPO_NAME}-chat-server

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,6 @@ name: test-chat-server
 trigger:
   branch:
     - main
-    - DOCSP-30565 # TODO: remove later when ready to merge
   event:
     - push
     - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,7 +85,7 @@ trigger:
 
 steps:
   # Deploys docker image associated with staging build that triggered promotion
-  - name: deploy-staging
+  - name: deploy-staging-chat-server
     image: quay.io/mongodb/drone-helm:v3
     settings:
       chart: mongodb/web-app
@@ -112,7 +112,7 @@ trigger:
 
 steps:
   # Builds and publishes Docker image for production
-  - name: publish-production
+  - name: publish-production-chat-server
     image: plugins/kaniko-ecr
     settings:
       create_repository: true
@@ -149,7 +149,7 @@ trigger:
 
 steps:
   # Deploys Docker image associated with production build that triggered promotion
-  - name: deploy-production
+  - name: deploy-production-chat-server
     image: quay.io/mongodb/drone-helm:v3
     settings:
       chart: mongodb/web-app

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
+---
 # ---
 # Chat Server pipelines
 # ---
----
 kind: pipeline
 type: kubernetes
 name: test-chat-server

--- a/.drone.yml
+++ b/.drone.yml
@@ -92,8 +92,8 @@ steps:
       chart_version: 4.12.3
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
-      release: ${DRONE_REPO_NAME}-chat-server
-      values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-staging,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=chat-server.docs.staging.corp.mongodb.com
+      release: chat-server
+      values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-staging,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME}-chat-server,ingress.enabled=true,ingress.hosts[0]=chat-server.docs.staging.corp.mongodb.com
       values_files: ["chat-server/environments/staging.yml"]
       api_server: https://api.staging.corp.mongodb.com
       kubernetes_token:

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
       # - npm run test
 
 ---
-depends_on: ["test"]
+depends_on: ["test-chat-server"]
 kind: pipeline
 type: kubernetes
 name: staging-build-chat-server
@@ -50,7 +50,7 @@ steps:
     settings:
       create_repository: true
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
-      repo: docs/${DRONE_REPO_NAME}
+      repo: docs/${DRONE_REPO_NAME}-chat-server
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}-staging
         - latest-staging
@@ -63,7 +63,6 @@ steps:
   - name: promote-staging
     image: drone/cli:1.4.0-alpine
     commands:
-      # TODO: how to incorporate entering the chat-server directory?
       - drone build promote mongodb/docs-chat ${DRONE_BUILD_NUMBER} staging
     environment:
       DRONE_SERVER: ${DRONE_SYSTEM_PROTO}://${DRONE_SYSTEM_HOST}
@@ -99,7 +98,7 @@ steps:
 
 ---
 # NOTE: not worrying about production stuff just yet
-depends_on: ["test"]
+depends_on: ["test-chat-server"]
 kind: pipeline
 type: kubernetes
 name: production-build-chat-server

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,7 +66,7 @@ steps:
   - name: promote-staging-chat-server
     image: drone/cli:1.4.0-alpine
     commands:
-      - drone build promote mongodb/docs-chat ${DRONE_BUILD_NUMBER} staging
+      - drone build promote mongodb/docs-chatbot ${DRONE_BUILD_NUMBER} staging
     environment:
       DRONE_SERVER: ${DRONE_SYSTEM_PROTO}://${DRONE_SYSTEM_HOST}
       DRONE_TOKEN:

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,7 @@ steps:
       - cd chat-server
       - npm ci
       - npm run lint
+      # TODO add back in when working test suite exists
       # Skipping testing for now since we don't have any tests
       # - npm run test
 
@@ -101,7 +102,10 @@ steps:
 
 ---
 # --------------------
-# NOTE: not worrying about production stuff just yet
+# TODO: Validate production deployment.
+# Not worrying about production stuff just yet.
+# The below config *should* work, but it hasn't been tested yet, so odds are that
+# it will need to be tweaked.
 # --------------------
 depends_on: ["test-chat-server"]
 kind: pipeline
@@ -119,7 +123,7 @@ steps:
     settings:
       create_repository: true
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
-      repo: docs/${DRONE_REPO_NAME}
+      repo: docs/${DRONE_REPO_NAME}-chat-server
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}-production
         - latest-production
@@ -159,8 +163,8 @@ steps:
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
       release: docs-chat
-      values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-production,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=chat-server.docs.prod.corp.mongodb.com
-      values_files: ["environments/production.yml"]
+      values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-production,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME}-chat-server,ingress.enabled=true,ingress.hosts[0]=chat-server.docs.prod.corp.mongodb.com
+      values_files: ["chat-server/environments/production.yml"]
       api_server: https://api.prod.corp.mongodb.com
       kubernetes_token:
         from_secret: prod_kubernetes_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -45,9 +45,11 @@ trigger:
 
 steps:
   # Builds and publishes Docker image for staging
-  - name: publish-staging
+  - name: publish-staging-chat-server
+    # TODO: find Dockerfile in the chat-server directory
     image: plugins/kaniko-ecr
     settings:
+      dockerfile: chat-server/Dockerfile
       create_repository: true
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
       repo: docs/${DRONE_REPO_NAME}-chat-server
@@ -60,7 +62,7 @@ steps:
         from_secret: ecr_secret_key
 
   # Promotes current drone build to staging environment
-  - name: promote-staging
+  - name: promote-staging-chat-server
     image: drone/cli:1.4.0-alpine
     commands:
       - drone build promote mongodb/docs-chat ${DRONE_BUILD_NUMBER} staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,10 @@
+# ---
+# Chat Server pipelines
+# ---
 ---
 kind: pipeline
 type: kubernetes
-name: test
+name: test-chat-server
 
 trigger:
   branch:
@@ -10,27 +13,35 @@ trigger:
   event:
     - push
     - tag
+  paths:
+    include:
+      - chat-server/**/*
 
 steps:
   - name: test
     image: node:18
     commands:
+      - cd chat-server
       - npm ci
       - npm run lint
       # Skipping testing for now since we don't have any tests
       # - npm run test
 
 ---
-depends_on: ['test']
+depends_on: ["test"]
 kind: pipeline
 type: kubernetes
-name: staging-build
+name: staging-build-chat-server
 
 trigger:
   branch:
     - main
+    - DOCSP-30565 # TODO: remove later when ready to merge
   event:
     - push
+  paths:
+    include:
+      - chat-server/**/*
 
 steps:
   # Builds and publishes Docker image for staging
@@ -52,7 +63,7 @@ steps:
   - name: promote-staging
     image: drone/cli:1.4.0-alpine
     commands:
-      # TODO: replace with our own server..real name TBD
+      # TODO: how to incorporate entering the chat-server directory?
       - drone build promote mongodb/docs-chat ${DRONE_BUILD_NUMBER} staging
     environment:
       DRONE_SERVER: ${DRONE_SYSTEM_PROTO}://${DRONE_SYSTEM_HOST}
@@ -62,7 +73,7 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: staging-deploy
+name: staging-deploy-chat-server
 
 trigger:
   event:
@@ -79,19 +90,19 @@ steps:
       chart_version: 4.12.3
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
-      # TODO: replace with our own server..real name TBD
       release: chat-server
-      values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-staging,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=snooty-data-api.docs.staging.corp.mongodb.com
-      values_files: ['environments/staging.yml']
+      values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-staging,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=chat-server.docs.staging.corp.mongodb.com
+      values_files: ["environments/staging.yml"]
       api_server: https://api.staging.corp.mongodb.com
       kubernetes_token:
         from_secret: staging_kubernetes_token
 
 ---
-depends_on: ['test']
+# NOTE: not worrying about production stuff just yet
+depends_on: ["test"]
 kind: pipeline
 type: kubernetes
-name: production-build
+name: production-build-chat-server
 
 trigger:
   event:
@@ -114,10 +125,9 @@ steps:
         from_secret: ecr_secret_key
 
   # Promotes current drone build to production environment
-  - name: promote-production
+  - name: promote-production-chat-server
     image: drone/cli:1.4.0-alpine
     commands:
-      # TODO: replace with our own server..real name TBD
       - drone build promote docs-chat ${DRONE_BUILD_NUMBER} production
     environment:
       DRONE_SERVER: ${DRONE_SYSTEM_PROTO}://${DRONE_SYSTEM_HOST}
@@ -127,7 +137,7 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: production-deploy
+name: production-deploy-chat-server
 
 trigger:
   event:
@@ -144,10 +154,9 @@ steps:
       chart_version: 4.12.3
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
-      # TODO: replace with our own server..real name TBD
       release: docs-chat
-      values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-production,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=snooty-data-api.docs.prod.corp.mongodb.com
-      values_files: ['environments/production.yml']
+      values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-production,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=chat-server.docs.prod.corp.mongodb.com
+      values_files: ["environments/production.yml"]
       api_server: https://api.prod.corp.mongodb.com
       kubernetes_token:
         from_secret: prod_kubernetes_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -94,7 +94,7 @@ steps:
       namespace: docs
       release: chat-server
       values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-staging,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=chat-server.docs.staging.corp.mongodb.com
-      values_files: ["environments/staging.yml"]
+      values_files: ["chat-server/environments/staging.yml"]
       api_server: https://api.staging.corp.mongodb.com
       kubernetes_token:
         from_secret: staging_kubernetes_token

--- a/chat-server/.drone.yml
+++ b/chat-server/.drone.yml
@@ -6,6 +6,7 @@ name: test
 trigger:
   branch:
     - main
+    - DOCSP-30565 # TODO: remove later when ready to merge
   event:
     - push
     - tag
@@ -16,7 +17,8 @@ steps:
     commands:
       - npm ci
       - npm run lint
-      - npm run test
+      # Skipping testing for now since we don't have any tests
+      # - npm run test
 
 ---
 depends_on: ['test']
@@ -31,7 +33,7 @@ trigger:
     - push
 
 steps:
-  # Bulds and publishes Docker image for staging
+  # Builds and publishes Docker image for staging
   - name: publish-staging
     image: plugins/kaniko-ecr
     settings:
@@ -78,7 +80,7 @@ steps:
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
       # TODO: replace with our own server..real name TBD
-      release: docs-chat
+      release: chat-server
       values: image.tag=git-${DRONE_COMMIT_SHA:0:7}-staging,image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=snooty-data-api.docs.staging.corp.mongodb.com
       values_files: ['environments/staging.yml']
       api_server: https://api.staging.corp.mongodb.com

--- a/chat-server/.eslintrc.js
+++ b/chat-server/.eslintrc.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   parser: '@typescript-eslint/parser',
   extends: ['plugin:@typescript-eslint/recommended', 'prettier'],
   ignorePatterns: ['dist/', 'node_modules/'],

--- a/chat-server/environments/production.yml
+++ b/chat-server/environments/production.yml
@@ -5,8 +5,9 @@ env:
   PORT: 3000
   SNOOTY_DB_NAME: docs_chat_prod
 
-envSecrets:
-  ATLAS_URI: chat-server-atlas-uri-prod
+# TODO: add this via kubectl when database is created
+# envSecrets:
+#   ATLAS_URI: chat-server-atlas-uri-prod
 
 ingress:
   enabled: true

--- a/chat-server/environments/production.yml
+++ b/chat-server/environments/production.yml
@@ -1,21 +1,20 @@
-# TODO: Set up production environment
-# service:
-#   targetPort: 3000
+service:
+  targetPort: 3000
 
-# env:
-#   PORT: 3000
-#   SNOOTY_DB_NAME: snooty_prod
+env:
+  PORT: 3000
+  SNOOTY_DB_NAME: docs_chat_prod
 
-# envSecrets:
-#   ATLAS_URI: snooty-data-api
+envSecrets:
+  ATLAS_URI: chat-server-atlas-uri-prod
 
-# ingress:
-#   enabled: true
-#   hosts:
-#     - snooty-data-api.docs.prod.corp.mongodb.com
+ingress:
+  enabled: true
+  hosts:
+    - chat-server.docs.prod.corp.mongodb.com
 
-# resources:
-#   limits:
-#     memory: 1300Mi
-#   requests:
-#     memory: 1100Mi
+resources:
+  limits:
+    memory: 1300Mi
+  requests:
+    memory: 1100Mi

--- a/chat-server/environments/staging.yml
+++ b/chat-server/environments/staging.yml
@@ -1,21 +1,20 @@
-# TODO: Set up staging environment
-# service:
-#   targetPort: 3000
+service:
+  targetPort: 3000
 
-# env:
-#   PORT: 3000
-#   SNOOTY_DB_NAME: snooty_stage
+env:
+  PORT: 3000
+  SNOOTY_DB_NAME: docs_chat_staging
 
-# envSecrets:
-#   ATLAS_URI: snooty-data-api-staging
+envSecrets:
+  ATLAS_URI: chat-server-atlas-uri-staging
 
-# ingress:
-#   enabled: true
-#   hosts:
-#     - snooty-data-api.docs.staging.corp.mongodb.com
+ingress:
+  enabled: true
+  hosts:
+    - chat-server.docs.staging.corp.mongodb.com
 
-# resources:
-#   limits:
-#     memory: 1300Mi
-#   requests:
-#     memory: 1100Mi
+resources:
+  limits:
+    memory: 1300Mi
+  requests:
+    memory: 1100Mi

--- a/chat-server/environments/staging.yml
+++ b/chat-server/environments/staging.yml
@@ -5,8 +5,9 @@ env:
   PORT: 3000
   SNOOTY_DB_NAME: docs_chat_staging
 
-envSecrets:
-  ATLAS_URI: chat-server-atlas-uri-staging
+# TODO: add this via kubectl when database is created
+# envSecrets:
+#   ATLAS_URI: chat-server-atlas-uri-staging
 
 ingress:
   enabled: true

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import { MongoClient, ObjectId } from 'mongodb';
 // Configure dotenv early so env variables can be read in imported files
 dotenv.config();
-import buildsRouter from './routes/builds';
+// import buildsRouter from './routes/builds';
 import projectsRouter from './routes/projects';
 import { setupClient } from './services/database';
 import { createMessage, initiateLogger } from './services/logger';
@@ -51,6 +51,9 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // TODO: Add routes
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
+  app.get('/', (_req, res) => {
+    res.send('Hello World! 🧙');
+  });
   app.use(errorHandler);
 
   return app;

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙🧙🧙🧙🧙🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙🧙🧙🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙🧙🧙🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙🧙🧙🧙🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙');
+    res.send('Hello World! 🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙🧙🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙🧙🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -52,7 +52,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   // app.use('/builds', buildsRouter);
   // app.use('/projects', projectsRouter);
   app.get('/', (_req, res) => {
-    res.send('Hello World! 🧙🧙🧙🧙🧙🧙🧙');
+    res.send('Hello World! 🧙🧙🧙🧙🧙🧙');
   });
   app.use(errorHandler);
 

--- a/chat-server/src/services/database.ts
+++ b/chat-server/src/services/database.ts
@@ -2,37 +2,37 @@ import { Db, MongoClient, ObjectId } from 'mongodb';
 import { initiateLogger } from './logger';
 
 // TODO: define interfaces for database documents
-// interface StaticAsset {
-//   checksum: string;
-//   key: string;
-// }
+interface StaticAsset {
+  checksum: string;
+  key: string;
+}
 
-// export interface AssetDocument {
-//   _id: string;
-//   data: BinaryData;
-// }
+export interface AssetDocument {
+  _id: string;
+  data: BinaryData;
+}
 
-// interface PageDocument {
-//   _id: ObjectId;
-//   page_id: string;
-//   filename: string;
-//   ast: object;
-//   source: string;
-//   static_assets: StaticAsset[];
-//   build_id: ObjectId;
-//   created_at: Date;
-// }
+interface PageDocument {
+  _id: ObjectId;
+  page_id: string;
+  filename: string;
+  ast: object;
+  source: string;
+  static_assets: StaticAsset[];
+  build_id: ObjectId;
+  created_at: Date;
+}
 
-// interface UpdatedPageDocument {
-//   _id: ObjectId;
-//   page_id: string;
-//   filename: string;
-//   ast: object;
-//   static_assets: StaticAsset[];
-//   created_at: Date;
-//   updated_at: Date;
-//   deleted: boolean;
-// }
+interface UpdatedPageDocument {
+  _id: ObjectId;
+  page_id: string;
+  filename: string;
+  ast: object;
+  static_assets: StaticAsset[];
+  created_at: Date;
+  updated_at: Date;
+  deleted: boolean;
+}
 
 export type PageDocType = PageDocument | UpdatedPageDocument;
 


### PR DESCRIPTION
Configuration of Drone pipeline for chat-server staging builds. Will configure prod builds as we get closer to go live. 

This will work for development purposes. 

Automatically pushes the server to staging env when a change is added to `main` branch. 