### PR TITLE
(DOCSP-30616): `POST /conversations/:conversationId/messages/` route, no streaming

### DIFF
--- a/chat-server/package-lock.json
+++ b/chat-server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.2",
         "common-tags": "^1.8.2",
+        "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "gpt3-tokenizer": "^1.1.5",
@@ -25,6 +26,7 @@
         "@babel/preset-env": "^7.22.5",
         "@babel/preset-typescript": "^7.22.5",
         "@types/common-tags": "^1.8.1",
+        "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
         "@types/stream-json": "^1.7.3",
@@ -3868,6 +3870,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.17",
       "dev": true,
@@ -5228,6 +5239,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -8251,6 +8274,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-hash": {
@@ -12827,6 +12858,15 @@
       "version": "2.1.2",
       "dev": true
     },
+    "@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/express": {
       "version": "4.17.17",
       "dev": true,
@@ -13704,6 +13744,15 @@
       "dev": true,
       "requires": {
         "browserslist": "^4.21.5"
+      }
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
       }
     },
     "create-require": {
@@ -15531,6 +15580,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/num-sort/-/num-sort-2.1.0.tgz",
       "integrity": "sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-hash": {
       "version": "3.0.0",

--- a/chat-server/package.json
+++ b/chat-server/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.2",
     "common-tags": "^1.8.2",
+    "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "gpt3-tokenizer": "^1.1.5",
@@ -38,6 +39,7 @@
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@types/common-tags": "^1.8.1",
+    "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/stream-json": "^1.7.3",

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -25,9 +25,7 @@ const errorHandler: ErrorRequestHandler = (err, req, res) => {
     res.end();
   }
 };
-
-// TODO: check with raymund if we'd need this for the current project
-// or if only snooty-data-api specific
+// Apply to all logs in the app
 const reqHandler: RequestHandler = (req, _res, next) => {
   const reqId = new ObjectId().toString();
   // Custom header specifically for a request ID. This ID will be used to track

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -1,14 +1,14 @@
 import express, { ErrorRequestHandler, RequestHandler } from "express";
+import cors from "cors";
 import "dotenv/config";
-import { MongoClient, ObjectId } from "mongodb";
 import { makeConversationsRouter } from "./routes/conversations";
-import { createMessage, logger } from "./services/logger";
-import { getRequestId } from "./utils";
 import { llm } from "./services/llm";
 import { embeddings } from "./services/embeddings";
 import { dataStreamer } from "./services/dataStreamer";
 import { content } from "./services/content";
 import { conversationsService } from "./services/conversations";
+import { ObjectId } from "mongodb";
+import { createMessage, logger } from "./services/logger";
 
 // General error handler; called at usage of next() in routes
 const errorHandler: ErrorRequestHandler = (err, req, res) => {
@@ -28,19 +28,20 @@ const errorHandler: ErrorRequestHandler = (err, req, res) => {
 
 // TODO: check with raymund if we'd need this for the current project
 // or if only snooty-data-api specific
-// const reqHandler: RequestHandler = (req, _res, next) => {
-//   const reqId = new ObjectId().toString();
-//   // Custom header specifically for a request ID. This ID will be used to track
-//   // logs related to the same request
-//   req.headers["req-id"] = reqId;
-//   const message = `Request for: ${req.url}`;
-//   logger.info(createMessage(message, req.body, reqId));
-//   next();
-// };
+const reqHandler: RequestHandler = (req, _res, next) => {
+  const reqId = new ObjectId().toString();
+  // Custom header specifically for a request ID. This ID will be used to track
+  // logs related to the same request
+  req.headers["req-id"] = reqId;
+  const message = `Request for: ${req.url}`;
+  logger.info(createMessage(message, req.body, reqId));
+  next();
+};
 
 export const setupApp = async () => {
   const app = express();
-  // app.use(reqHandler);
+  app.use(cors()); // TODO: add specific options to only allow certain origins
+  app.use(reqHandler);
   app.use(
     "/conversations",
     makeConversationsRouter({

--- a/chat-server/src/routes/conversations/addMessageToConversation.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.ts
@@ -3,12 +3,10 @@ import {
   Response as ExpressResponse,
   NextFunction,
 } from "express";
+import { ObjectId } from "mongodb";
 import { OpenAiChatMessage } from "../../integrations/openai";
-import { ContentServiceInterface } from "../../services/content";
-import {
-  ConversationsServiceInterface,
-  Message,
-} from "../../services/conversations";
+import { Content, ContentServiceInterface } from "../../services/content";
+import { ConversationsServiceInterface } from "../../services/conversations";
 import { DataStreamerServiceInterface } from "../../services/dataStreamer";
 import { EmbeddingService } from "../../services/embeddings";
 import {
@@ -16,17 +14,17 @@ import {
   OpenAiAwaitedResponse,
   OpenAiStreamingResponse,
 } from "../../services/llm";
-import { ObjectId } from "mongodb";
+import { ApiConversation, convertMessageFromDbToApi } from "./utils";
+import { sendErrorResponse } from "../../utils";
+import { logger } from "../../services/logger";
+
+const MAX_INPUT_LENGTH = 300; // magic number for max input size for LLM
 
 interface RequestWithStreamParam extends ExpressRequest {
   params: {
     stream: string;
   };
-  body: {
-    conversation: Message[];
-    id: string;
-    ipAddress: string;
-  };
+  body: ApiConversation;
 }
 export interface AddMessageToConversationRouteParams {
   content: ContentServiceInterface;
@@ -50,66 +48,157 @@ export function makeAddMessageToConversationRoute({
     try {
       // TODO: implement type checking on the request
 
+      if (!validateApiConversationFormatting({ conversation: req.body })) {
+        return sendErrorResponse(res, 400, "Invalid conversation formatting");
+      }
+
       const ipAddress = "<NOT CAPTURING IP ADDRESS YET>"; // TODO: refactor to get IP address with middleware
 
       const stream = Boolean(req.params.stream);
-      const { conversation, id } = req.body;
-      const latestMessage = conversation[conversation.length - 1];
-      // TODO: implement error handling
-      const { embedding } = await embeddings.createEmbedding({
-        text: latestMessage.content,
-        userIp: ipAddress,
-      });
-      const chunks = await content.findVectorMatches({
-        embedding,
-      });
-      const chunkTexts = chunks.map((chunk) => chunk.text);
+      const { messages, id } = req.body;
+      const latestMessage = messages[messages.length - 1];
+      if (latestMessage.content.length > MAX_INPUT_LENGTH) {
+        return sendErrorResponse(res, 400, "Message too long");
+      }
 
       const conversationInDb = await conversations.findById({
         _id: new ObjectId(id),
       });
       if (!conversationInDb) {
-        return res.status(404).json({ error: "Conversation not found" });
+        return sendErrorResponse(res, 404, "Conversation not found");
       }
-      if (conversationInDb.ipAddress !== req.body.ipAddress) {
-        return res.status(403).json({ error: "IP address does not match" });
+      if (conversationInDb.ipAddress !== ipAddress) {
+        return sendErrorResponse(res, 403, "IP address does not match");
       }
+
+      // Find content matches for latest message
+      // TODO: consider refactoring this to feed in all messages to the embeddings service
+      // And then as a future step, we can use LLM pre-processing to create a better input
+      // to the embedding service.
+      const chunks = await getContentForText({
+        embeddings,
+        ipAddress,
+        text: latestMessage.content,
+        content,
+      });
+
+      const chunkTexts = chunks.map((chunk) => chunk.text);
 
       let answer;
       if (stream) {
-        answer = await dataStreamer.answer({
-          res,
-          answer: llm.answerQuestionStream({
+        throw new Error("Streaming not implemented yet");
+        // answer = await dataStreamer.answer({
+        //   res,
+        //   answer: llm.answerQuestionStream({
+        //     messages: [
+        //       ...conversationInDb.messages,
+        //       latestMessage,
+        //     ] as OpenAiChatMessage[],
+        //     chunks: chunkTexts,
+        //   }),
+        //   conversation: conversationInDb,
+        //   chunks,
+        // });
+      } else {
+        try {
+          const messages = [
+            ...conversationInDb.messages,
+            latestMessage,
+          ] as OpenAiChatMessage[];
+          logger.info(`LLM query: ${JSON.stringify(messages)}`);
+          answer = await llm.answerQuestionAwaited({
             messages: [
               ...conversationInDb.messages,
               latestMessage,
             ] as OpenAiChatMessage[],
             chunks: chunkTexts,
-          }),
-          conversation: conversationInDb,
-          chunks,
-        });
-      } else {
-        answer = await llm.answerQuestionAwaited({
-          messages: [
-            ...conversationInDb.messages,
-            latestMessage,
-          ] as OpenAiChatMessage[],
-          chunks: chunkTexts,
-        });
-
-        const successfulOperation = await conversations.addUserMessage({
-          conversationId: conversationInDb._id,
-          content: answer.content,
-        });
-        if (successfulOperation) {
-          return res.status(200).send(answer);
-        } else {
-          return res.status(500).json({ error: "Internal server error" });
+          });
+          logger.info(`LLM response: ${JSON.stringify(answer)}`);
+        } catch (err) {
+          return sendErrorResponse(res, 500, "Error from LLM");
         }
+        // TODO: consider refactoring addConversationMessage to take in an array of messages.
+        // Would limit database calls.
+        await conversations.addConversationMessage({
+          conversationId: conversationInDb._id,
+          content: latestMessage.content,
+          role: "user",
+        });
+        const newMessage = await conversations.addConversationMessage({
+          conversationId: conversationInDb._id,
+          content: answer.content + generateFurtherReading({ chunks }),
+          role: "assistant",
+        });
+        const apiRes = convertMessageFromDbToApi(newMessage);
+        res.status(200).json(apiRes);
       }
     } catch (err) {
       next(err);
     }
   };
+}
+
+export interface GetContentForTextParams {
+  embeddings: EmbeddingService;
+  ipAddress: string;
+  text: string;
+  content: ContentServiceInterface;
+}
+
+export async function getContentForText({
+  embeddings,
+  ipAddress,
+  text,
+  content,
+}: GetContentForTextParams) {
+  const { embedding } = await embeddings.createEmbedding({
+    text,
+    userIp: ipAddress,
+  });
+  const chunks = await content.findVectorMatches({
+    embedding,
+  });
+  return chunks;
+}
+
+export interface GenerateFurtherReadingParams {
+  chunks: Content[];
+}
+export function generateFurtherReading({
+  chunks,
+}: GenerateFurtherReadingParams) {
+  const heading = "\n\n## Further Reading\n\n";
+  const uniqueLinks = new Array(new Set(chunks.map((chunk) => chunk.url)));
+  const linksText =
+    uniqueLinks.reduce((acc, link) => {
+      const linkListItem = `- ${link}\n`;
+      return acc + linkListItem;
+    }, "") + "\n";
+  return heading + linksText;
+}
+
+export function validateApiConversationFormatting({
+  conversation,
+}: {
+  conversation: ApiConversation;
+}) {
+  const { messages } = conversation;
+  if (
+    messages?.length === 0 || // Must be messages in the conversation
+    messages.length % 2 !== 0 // Must be an even number of messages
+  ) {
+    return false;
+  }
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const isAssistant = i % 2 === 0;
+    if (isAssistant && message.role !== "assistant") {
+      return false;
+    }
+    if (!isAssistant && message.role !== "user") {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/chat-server/src/routes/conversations/createConversation.ts
+++ b/chat-server/src/routes/conversations/createConversation.ts
@@ -4,7 +4,7 @@ import {
   Request as ExpressRequest,
 } from "express";
 import { ConversationsServiceInterface } from "../../services/conversations";
-import { convertConversationToResponse } from "./utils";
+import { convertConversationFromDbToApi } from "./utils";
 import { logger } from "../../services/logger";
 
 export interface CreateConversationRouteParams {
@@ -28,7 +28,7 @@ export function makeCreateConversationRoute({
       });
 
       const responseConversation =
-        convertConversationToResponse(conversationInDb);
+        convertConversationFromDbToApi(conversationInDb);
       res.status(200).json({ conversation: responseConversation });
       logger.info(`Created conversation ${conversationInDb._id.toString()}`);
     } catch (err) {

--- a/chat-server/src/routes/conversations/createConversation.ts
+++ b/chat-server/src/routes/conversations/createConversation.ts
@@ -19,8 +19,9 @@ export function makeCreateConversationRoute({
     next: NextFunction
   ) => {
     try {
-      // TODO: implement type checking on the request
-      const ipAddress = "<NOT CAPTURING IP ADDRESS YET>"; // TODO: refactor to get IP address with middleware
+      // TODO:(DOCSP-30863) implement type checking on the request
+
+      const ipAddress = "<NOT CAPTURING IP ADDRESS YET>"; // TODO:(DOCSP-30843) refactor to get IP address with middleware
       logger.info(`Creating conversation for IP address ${ipAddress}`);
 
       const conversationInDb = await conversations.create({
@@ -29,7 +30,7 @@ export function makeCreateConversationRoute({
 
       const responseConversation =
         convertConversationFromDbToApi(conversationInDb);
-      res.status(200).json({ conversation: responseConversation });
+      res.status(200).json(responseConversation);
       logger.info(`Created conversation ${conversationInDb._id.toString()}`);
     } catch (err) {
       next(err);

--- a/chat-server/src/routes/conversations/rateMessage.ts
+++ b/chat-server/src/routes/conversations/rateMessage.ts
@@ -30,9 +30,9 @@ export function makeRateMessageRoute({
     next: NextFunction
   ) => {
     try {
-      // TODO: implement type checking on the request
+      // TODO:(DOCSP-30863) implement type checking on the request
 
-      const ipAddress = ""; // TODO: refactor to get IP address with middleware
+      const ipAddress = "<NOT CAPTURING IP ADDRESS YET>"; // TODO:(DOCSP-30843) refactor to get IP address with middleware
 
       const { conversationId, messageId } = req.params;
       const { rating } = req.body;

--- a/chat-server/src/routes/conversations/utils.ts
+++ b/chat-server/src/routes/conversations/utils.ts
@@ -1,30 +1,34 @@
-import { Conversation } from "../../services/conversations";
+import { Conversation, Message } from "../../services/conversations";
 
-export interface MessageResponse {
+export interface ApiMessage {
   id: string;
   role: string;
   content: string;
   rating?: boolean;
   createdAt: number;
 }
-export interface ConversationResponse {
+export interface ApiConversation {
   _id: string;
-  messages: MessageResponse[];
+  messages: ApiMessage[];
   createdAt: number;
 }
-export function convertConversationToResponse(
+
+export function convertMessageFromDbToApi(message: Message): ApiMessage {
+  return {
+    id: message.id.toString(),
+    role: message.role,
+    content: message.content,
+    rating: message.rating,
+    createdAt: message.createdAt.getTime(),
+  };
+}
+export function convertConversationFromDbToApi(
   conversation: Conversation
-): ConversationResponse {
+): ApiConversation {
   conversation.messages.shift(); // Remove the system prompt
   return {
     _id: conversation._id.toString(),
-    messages: conversation.messages.map((message) => ({
-      id: message.id.toString(),
-      role: message.role,
-      content: message.content,
-      rating: message.rating,
-      createdAt: message.createdAt.getTime(),
-    })),
+    messages: conversation.messages.map(convertMessageFromDbToApi),
     createdAt: conversation.createdAt.getTime(),
   };
 }

--- a/chat-server/src/services/content.ts
+++ b/chat-server/src/services/content.ts
@@ -74,7 +74,7 @@ export class ContentService implements ContentServiceInterface {
   }
 }
 
-const options: ContentServiceOptions = {
+export const options: ContentServiceOptions = {
   k: 10,
   path: "embedding",
   indexName: mongodb.vectorSearchIndexName || "default",

--- a/chat-server/src/services/llm.ts
+++ b/chat-server/src/services/llm.ts
@@ -1,5 +1,5 @@
 // TODO: add better error handling logic like the embeddings service
-import { ChatMessage, ChatCompletions } from "@azure/openai";
+import { ChatCompletions } from "@azure/openai";
 import "dotenv/config";
 import {
   OpenAiChatClient,

--- a/chat-server/src/utils.ts
+++ b/chat-server/src/utils.ts
@@ -4,6 +4,7 @@ import {
 } from "express";
 import { Conversation } from "./services/conversations";
 import { logger } from "./services/logger";
+import { stripIndent } from "common-tags";
 
 /**
  * Checks for req-id Request Header. Returns an empty string if the header is not
@@ -26,10 +27,12 @@ export const getRequestId = (req: ExpressRequest) => {
 export const sendErrorResponse = (
   res: ExpressResponse,
   httpStatus: number,
-  errorMessage: string
+  errorMessage: string,
+  errorDetails?: string
 ) => {
   logger.error(
-    `Responding with ${httpStatus} status and error message: ${errorMessage}`
+    stripIndent`Responding with ${httpStatus} status and error message: ${errorMessage}.
+    ${errorDetails ? `Error details: ${errorDetails}` : ""}`
   );
   return res.status(httpStatus).json({ error: errorMessage });
 };

--- a/chat-server/src/utils.ts
+++ b/chat-server/src/utils.ts
@@ -1,5 +1,9 @@
-import { Request } from "express";
+import {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from "express";
 import { Conversation } from "./services/conversations";
+import { logger } from "./services/logger";
 
 /**
  * Checks for req-id Request Header. Returns an empty string if the header is not
@@ -8,7 +12,7 @@ import { Conversation } from "./services/conversations";
  * @param req
  * @returns
  */
-export const getRequestId = (req: Request) => {
+export const getRequestId = (req: ExpressRequest) => {
   const reqId = req.headers["req-id"];
   if (!reqId) {
     return undefined;
@@ -17,4 +21,15 @@ export const getRequestId = (req: Request) => {
   } else {
     return reqId;
   }
+};
+
+export const sendErrorResponse = (
+  res: ExpressResponse,
+  httpStatus: number,
+  errorMessage: string
+) => {
+  logger.error(
+    `Responding with ${httpStatus} status and error message: ${errorMessage}`
+  );
+  return res.status(httpStatus).json({ error: errorMessage });
 };

--- a/chat-server/tests/routes/conversations.test.ts
+++ b/chat-server/tests/routes/conversations.test.ts
@@ -1,40 +1,73 @@
 import request from "supertest";
 import "dotenv/config";
 import { MongoDB } from "../../src/integrations/mongodb";
-import { ASSISTANT_PROMPT } from "../../src/integrations/openai";
-
-import { ConversationsService } from "../../src/services/conversations";
-
-import { makeCreateConversationRoute } from "../../src/routes/conversations/createConversation";
+import {
+  ASSISTANT_PROMPT,
+  OpenAiChatClient,
+  OpenAiEmbeddingsClient,
+} from "../../src/integrations/openai";
+import {
+  Conversation,
+  ConversationsService,
+  Message,
+} from "../../src/services/conversations";
 import express from "express";
-import { ApiConversation } from "../../src/routes/conversations/utils";
+import {
+  AddMessageRequestBody,
+  makeAddMessageToConversationRoute,
+  convertDbMessageToOpenAiMessage,
+  generateFurtherReading,
+  validateApiConversationFormatting,
+  getContentForText,
+} from "../../src/routes/conversations/addMessageToConversation";
+import { makeCreateConversationRoute } from "../../src/routes/conversations/createConversation";
+import {
+  ApiConversation,
+  ApiMessage,
+} from "../../src/routes/conversations/utils";
+import {
+  Content,
+  ContentService,
+  options as contentServiceOptions,
+} from "../../src/services/content";
+import {
+  EmbeddingService,
+  OpenAiEmbeddingProvider,
+} from "../../src/services/embeddings";
+import { OpenAiLlmProvider } from "../../src/services/llm";
+import { DataStreamerService } from "../../src/services/dataStreamer";
+import { stripIndent } from "common-tags";
+import { ObjectId } from "mongodb";
 
-const { MONGODB_CONNECTION_URI, MONGODB_DATABASE_NAME } = process.env;
-
-const mongodb = new MongoDB(MONGODB_CONNECTION_URI!, MONGODB_DATABASE_NAME!);
-
-const testConversationDb = mongodb.mongoClient.db(
-  `conversations-test-${Date.now()}`
-);
-const conversations = new ConversationsService(testConversationDb);
+jest.setTimeout(100000);
+const {
+  MONGODB_CONNECTION_URI,
+  MONGODB_DATABASE_NAME,
+  OPENAI_ENDPOINT,
+  OPENAI_API_KEY,
+  OPENAI_EMBEDDING_DEPLOYMENT,
+  OPENAI_EMBEDDING_MODEL_VERSION,
+  OPENAI_CHAT_COMPLETION_DEPLOYMENT,
+} = process.env;
 
 describe("Conversations Router", () => {
-  afterAll(async () => {
-    await testConversationDb.dropDatabase();
-    await mongodb.close();
-  });
-
-  const app = express();
-  app.use(express.json()); // for parsing application/json
-
   // create route with mock service
   describe("POST /conversations/", () => {
+    const app = express();
+    app.use(express.json()); // for parsing application/json
+    const testDbName = `conversations-test-${Date.now()}`;
+    const mongodb = new MongoDB(MONGODB_CONNECTION_URI!, testDbName);
+
+    const conversations = new ConversationsService(mongodb.db);
+    afterAll(async () => {
+      await mongodb.db.dropDatabase();
+      await mongodb.close();
+    });
     app.post("/conversations/", makeCreateConversationRoute({ conversations }));
-    it("should respond with 204 and create a conversation", async () => {
+    it("should respond with 200 and create a conversation", async () => {
       const before = Date.now();
       const res = await request(app).post("/conversations/").send();
-      const conversation: ApiConversation = res.body.conversation;
-      console.log({ conversation });
+      const conversation: ApiConversation = res.body;
       const [assistantMessage] = conversation.messages;
       expect(res.statusCode).toEqual(200);
 
@@ -44,6 +77,357 @@ describe("Conversations Router", () => {
       expect(assistantMessage.role).toBe(ASSISTANT_PROMPT.role);
       expect(assistantMessage.rating).toBe(undefined);
       expect(assistantMessage.createdAt).toBeGreaterThan(before);
+      const count = await mongodb.db
+        .collection("conversations")
+        .countDocuments();
+      expect(count).toBe(1);
+    });
+  });
+
+  describe("POST /conversations/:conversationId/messages", () => {
+    const app = express();
+    app.use(express.json()); // for parsing application/json
+    // set up conversations service
+    const conversationMessageTestDbName = `convo-msg-test-${Date.now()}`;
+    const conversationsMongoDb = new MongoDB(
+      MONGODB_CONNECTION_URI!,
+      conversationMessageTestDbName
+    );
+    const conversations = new ConversationsService(conversationsMongoDb.db);
+
+    // set up content service
+    const contentMongoDb = new MongoDB(
+      MONGODB_CONNECTION_URI!,
+      MONGODB_DATABASE_NAME!
+    );
+    const content = new ContentService(
+      contentMongoDb.db,
+      contentServiceOptions
+    );
+
+    // set up embeddings service
+    const embeddings = new EmbeddingService(
+      new OpenAiEmbeddingProvider(
+        new OpenAiEmbeddingsClient(
+          OPENAI_ENDPOINT!,
+          OPENAI_EMBEDDING_DEPLOYMENT!,
+          OPENAI_API_KEY!,
+          OPENAI_EMBEDDING_MODEL_VERSION!
+        )
+      )
+    );
+
+    // set up llm service
+    const llm = new OpenAiLlmProvider(
+      new OpenAiChatClient(
+        OPENAI_ENDPOINT!,
+        OPENAI_CHAT_COMPLETION_DEPLOYMENT!,
+        OPENAI_API_KEY!
+      )
+    );
+
+    // set up data streamer
+    // TODO: make real data streamer
+    const dataStreamer = new DataStreamerService();
+
+    app.post(
+      "/conversations/:conversationId/messages/",
+      makeAddMessageToConversationRoute({
+        conversations,
+        content,
+        embeddings,
+        llm,
+        dataStreamer,
+      })
+    );
+    // For set up. Need to create conversation before can add to it.
+    app.post("/conversations/", makeCreateConversationRoute({ conversations }));
+    let _id: string;
+    beforeEach(async () => {
+      const createConversationRes = await request(app)
+        .post("/conversations/")
+        .send();
+      const res: ApiConversation = createConversationRes.body;
+      _id = res._id;
+    });
+
+    afterAll(async () => {
+      await conversationsMongoDb.db.dropDatabase();
+      await conversationsMongoDb.close();
+      await contentMongoDb.close();
+    });
+
+    describe("Awaited response", () => {
+      it("should respond with 200, add messages to the conversation, and respond", async () => {
+        const requestBody: AddMessageRequestBody = {
+          message:
+            "how can i use mongodb products to help me build my new mobile app?",
+        };
+        const res = await request(app)
+          .post(`/conversations/${_id}/messages/`)
+          .send(requestBody);
+        const message: ApiMessage = res.body;
+        expect(res.statusCode).toEqual(200);
+        expect(message.role).toBe("assistant");
+        expect(message.content).toContain("Realm");
+        const request2Body: AddMessageRequestBody = {
+          message: stripIndent`i'm want to learn more about this Realm thing. a few questions:
+            can i use realm with javascript?
+            where does realm save data? in the cloud?
+            `,
+        };
+        const res2 = await request(app)
+          .post(`/conversations/${_id}/messages/`)
+          .send(request2Body);
+        const message2: ApiMessage = res2.body;
+        expect(res2.statusCode).toEqual(200);
+        expect(message2.role).toBe("assistant");
+        expect(message2.content).toContain("Realm");
+        const conversationInDb = await conversationsMongoDb.db
+          .collection<Conversation>("conversations")
+          .findOne({
+            _id: new ObjectId(_id),
+          });
+        expect(conversationInDb?.messages).toHaveLength(6); // system, assistant, user, assistant, user, assistant
+      });
+    });
+
+    describe.skip("Streamed response", () => {
+      // TODO: (DOCSP-30620) add in when data streamer is implemented
+    });
+    describe.skip("Error handing", () => {
+      // TODO: (DOCSP-30945) add in soon. just not including in DOCSP-30616 so that we can build on top of it
+    });
+
+    describe("Utility functions", () => {
+      test("convertDbMessageToOpenAiMessage()", () => {
+        const sampleDbMessage: Message = {
+          id: new ObjectId(),
+          content: "hello",
+          role: "user",
+          createdAt: new Date(),
+          rating: true,
+        };
+
+        const sampleApiMessage =
+          convertDbMessageToOpenAiMessage(sampleDbMessage);
+        expect(sampleApiMessage).toStrictEqual({
+          content: sampleDbMessage.content,
+          role: sampleDbMessage.role,
+        });
+      });
+
+      describe("getContentForText()", () => {
+        const ipAddress = "someIpAddress";
+        test("Should return content for relevant text", async () => {
+          const text = "MongoDB";
+
+          const chunks = await getContentForText({
+            embeddings,
+            text,
+            content,
+            ipAddress,
+          });
+          expect(chunks).toBeDefined();
+          expect(chunks.length).toBeGreaterThan(0);
+        });
+        test("Should not return content for irrelevant text", async () => {
+          const text =
+            "asdlfkjasdlfkjasdlfkjasdlfkjasdlfkjasdlfkjasdlfkjafdshgjfkhfdugytfasfghjkujufgjdfhstgragtyjuikol";
+          const chunks = await getContentForText({
+            embeddings,
+            text,
+            content,
+            ipAddress,
+          });
+          expect(chunks).toBeDefined();
+          expect(chunks.length).toBe(0);
+        });
+      });
+      describe("generateFurtherReading()", () => {
+        // Chunk 1 and 2 are the same page. Chunk 3 is a different page.
+        const chunk1 = {
+          _id: new ObjectId(),
+          url: "https://mongodb.com/docs/realm/sdk/node/",
+          text: "blah blah blah",
+          numTokens: 100,
+          embedding: [0.1, 0.2, 0.3],
+          lastUpdated: new Date(),
+          site: {
+            name: "MongoDB Realm",
+            url: "https://mongodb.com/docs/realm/",
+          },
+        };
+        const chunk2 = {
+          _id: new ObjectId(),
+          url: "https://mongodb.com/docs/realm/sdk/node/",
+          text: "blah blah blah",
+          numTokens: 100,
+          embedding: [0.1, 0.2, 0.3],
+          lastUpdated: new Date(),
+          site: {
+            name: "MongoDB Realm",
+            url: "https://mongodb.com/docs/realm/",
+          },
+        };
+        const chunk3 = {
+          _id: new ObjectId(),
+          url: "https://mongodb.com/docs/realm/sdk/node/xyz",
+          text: "blah blah blah",
+          numTokens: 100,
+          embedding: [0.1, 0.2, 0.3],
+          lastUpdated: new Date(),
+          site: {
+            name: "MongoDB Realm",
+            url: "https://mongodb.com/docs/realm/",
+          },
+        };
+        test("No sources should return empty string", () => {
+          const noChunks: Content[] = [];
+          const noFurtherReading = generateFurtherReading({ chunks: noChunks });
+          expect(noFurtherReading).toEqual("");
+        });
+        test("One source should return one link", () => {
+          const oneChunk: Content[] = [chunk1];
+          const oneFurtherReading = generateFurtherReading({
+            chunks: oneChunk,
+          });
+          const expectedOneFurtherReading = `\n\nArticles Referenced:\n${oneChunk[0].url}\n\n`;
+          expect(oneFurtherReading).toEqual(expectedOneFurtherReading);
+        });
+        test("Multiple sources from same page should return one link", () => {
+          const twoChunksSamePage: Content[] = [chunk1, chunk2];
+          const oneFurtherReadingSamePage = generateFurtherReading({
+            chunks: twoChunksSamePage,
+          });
+          const expectedOneFurtherReadingSamePage = `\n\nArticles Referenced:\n${twoChunksSamePage[0].url}\n\n`;
+          expect(oneFurtherReadingSamePage).toEqual(
+            expectedOneFurtherReadingSamePage
+          );
+        });
+        test("Multiple sources from different pages should return 1 link per page", () => {
+          const twoChunksDifferentPage: Content[] = [chunk1, chunk3];
+          const multipleFurtherReadingDifferentPage = generateFurtherReading({
+            chunks: twoChunksDifferentPage,
+          });
+          const expectedMultipleFurtherReadingDifferentPage = `\n\nArticles Referenced:\n${twoChunksDifferentPage[0].url}\n${twoChunksDifferentPage[1].url}\n\n`;
+          expect(multipleFurtherReadingDifferentPage).toEqual(
+            expectedMultipleFurtherReadingDifferentPage
+          );
+          // All three sources. Two from the same page. One from a different page.
+          const threeChunks: Content[] = [chunk1, chunk2, chunk3];
+          const multipleSourcesWithSomePageOverlap = generateFurtherReading({
+            chunks: threeChunks,
+          });
+          const expectedMultipleSourcesWithSomePageOverlap = `\n\nArticles Referenced:\n${threeChunks[0].url}\n${threeChunks[2].url}\n\n`;
+          expect(multipleSourcesWithSomePageOverlap).toEqual(
+            expectedMultipleSourcesWithSomePageOverlap
+          );
+        });
+      });
+      describe("validateApiConversationFormatting()", () => {
+        test("Should validate correctly formatted conversation", () => {
+          const correctlyFormattedConversation: ApiConversation = {
+            _id: new ObjectId().toHexString(),
+            messages: [
+              {
+                content: "hi",
+                role: "assistant",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+              {
+                content: "hello",
+                role: "user",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+              {
+                content: "bye",
+                role: "assistant",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+              {
+                content: "good bye",
+                role: "user",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+            ],
+            createdAt: Date.now(),
+          };
+          const validation = validateApiConversationFormatting({
+            conversation: correctlyFormattedConversation,
+          });
+          expect(validation).toBe(true);
+        });
+        test("Should not validate empty conversation", () => {
+          const emptyConversation: ApiConversation = {
+            _id: new ObjectId().toHexString(),
+            messages: [],
+            createdAt: Date.now(),
+          };
+          const validation = validateApiConversationFormatting({
+            conversation: emptyConversation,
+          });
+          expect(validation).toBe(false);
+        });
+        test("Should not validate odd number of messages", () => {
+          const oddNumberOfMessages: ApiConversation = {
+            _id: new ObjectId().toHexString(),
+            messages: [
+              {
+                content: "hi",
+                role: "assistant",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+              {
+                content: "hello",
+                role: "user",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+              {
+                content: "bye",
+                role: "assistant",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+            ],
+            createdAt: Date.now(),
+          };
+          const validation = validateApiConversationFormatting({
+            conversation: oddNumberOfMessages,
+          });
+          expect(validation).toBe(false);
+        });
+        test("Should not validate incorrect conversation order", () => {
+          const incorrectConversationOrder: ApiConversation = {
+            _id: new ObjectId().toHexString(),
+            messages: [
+              {
+                content: "hi",
+                role: "assistant",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+              {
+                content: "bye",
+                role: "assistant",
+                createdAt: Date.now(),
+                id: new ObjectId().toHexString(),
+              },
+            ],
+            createdAt: Date.now(),
+          };
+          const validation = validateApiConversationFormatting({
+            conversation: incorrectConversationOrder,
+          });
+          expect(validation).toBe(false);
+        });
+      });
     });
   });
 });

--- a/chat-server/tests/routes/conversations.test.ts
+++ b/chat-server/tests/routes/conversations.test.ts
@@ -1,25 +1,13 @@
 import request from "supertest";
 import "dotenv/config";
 import { MongoDB } from "../../src/integrations/mongodb";
-import {
-  ASSISTANT_PROMPT,
-  OpenAiChatClient,
-  OpenAiEmbeddingsClient,
-  SYSTEM_PROMPT,
-} from "../../src/integrations/openai";
-import {
-  ContentService,
-  ContentServiceOptions,
-} from "../../src/services/content";
+import { ASSISTANT_PROMPT } from "../../src/integrations/openai";
+
 import { ConversationsService } from "../../src/services/conversations";
-import { DataStreamerService } from "../../src/services/dataStreamer";
-import {
-  EmbeddingService,
-  OpenAiEmbeddingProvider,
-} from "../../src/services/embeddings";
+
 import { makeCreateConversationRoute } from "../../src/routes/conversations/createConversation";
 import express from "express";
-import { ConversationResponse } from "../../src/routes/conversations/utils";
+import { ApiConversation } from "../../src/routes/conversations/utils";
 
 const { MONGODB_CONNECTION_URI, MONGODB_DATABASE_NAME } = process.env;
 
@@ -45,7 +33,7 @@ describe("Conversations Router", () => {
     it("should respond with 204 and create a conversation", async () => {
       const before = Date.now();
       const res = await request(app).post("/conversations/").send();
-      const conversation: ConversationResponse = res.body.conversation;
+      const conversation: ApiConversation = res.body.conversation;
       console.log({ conversation });
       const [assistantMessage] = conversation.messages;
       expect(res.statusCode).toEqual(200);


### PR DESCRIPTION
Add non-streaming version of `POST /conversations/:messageId/messages/`. 

Note that I didn't implement some tests here in order to merge changes and get integrated with FE. Will return to tests in future work. 