### PR TITLE
Add minor optimization for rate-limited embed requests

### DIFF
--- a/chat-core/src/OpenAiEmbedFunc.test.ts
+++ b/chat-core/src/OpenAiEmbedFunc.test.ts
@@ -71,7 +71,7 @@ describe("OpenAiEmbedFunc", () => {
       try {
         await embed({ text: "", userIp: "" });
       } catch (e: any) {
-        // Expected to fail - server returns 400
+        // Expected to fail - server returns 429
         expect(e.message).toContain("Request failed with status code 429");
       }
       expect(serverHitCount).toBe(3);

--- a/chat-core/src/OpenAiEmbedFunc.ts
+++ b/chat-core/src/OpenAiEmbedFunc.ts
@@ -99,8 +99,21 @@ export const makeOpenAiEmbedFunc = ({
           }
 
           logger.info(
-            `OpenAI Embedding API rate limited (attempt ${attemptNumber - 1})`
+            `OpenAI Embedding API rate limited (attempt ${
+              attemptNumber - 1
+            }): ${error.message}`
           );
+
+          // Quick optimization for retry where we wait as long as it tells us
+          // to (if it does)
+          const matches = /retry after ([0-9]+) seconds/.exec(error.message);
+          const waitSeconds = matches ? parseInt(matches[1]) : 0;
+          if (waitSeconds) {
+            await new Promise((resolve) =>
+              setTimeout(resolve, waitSeconds * 1000)
+            );
+          }
+
           return true; // Keep trying until max attempts
         },
       }

--- a/chat-core/src/OpenAiEmbedFunc.ts
+++ b/chat-core/src/OpenAiEmbedFunc.ts
@@ -90,10 +90,11 @@ export const makeOpenAiEmbedFunc = ({
             data: { error },
           } = err.response;
 
+          const errorMessage = error?.message ?? "Unknown error";
           if (status !== 429 /* HTTP 429: Too Many Requests */) {
             const message = stripIndent`OpenAI Embedding API returned an error:
 - status: ${status}
-- error: ${JSON.stringify(error)}`;
+- error: ${errorMessage}`;
             logger.error(message);
             return false;
           }
@@ -101,12 +102,12 @@ export const makeOpenAiEmbedFunc = ({
           logger.info(
             `OpenAI Embedding API rate limited (attempt ${
               attemptNumber - 1
-            }): ${error.message}`
+            }): ${errorMessage}`
           );
 
           // Quick optimization for retry where we wait as long as it tells us
           // to (if it does)
-          const matches = /retry after ([0-9]+) seconds/.exec(error.message);
+          const matches = /retry after ([0-9]+) seconds/.exec(errorMessage);
           const waitSeconds = matches ? parseInt(matches[1]) : 0;
           if (waitSeconds) {
             await new Promise((resolve) =>

--- a/ingest/src/commands/embed.ts
+++ b/ingest/src/commands/embed.ts
@@ -32,6 +32,10 @@ const commandModule: CommandModule<unknown, EmbeddedContentCommandArgs> = {
       apiKey: OPENAI_API_KEY,
       apiVersion: OPENAI_EMBEDDING_MODEL_VERSION,
       deployment: OPENAI_EMBEDDING_DEPLOYMENT,
+      backoffOptions: {
+        numOfAttempts: 25,
+        startingDelay: 1000,
+      },
     });
 
     const store = await makeDatabaseConnection({


### PR DESCRIPTION
Jira: N/A

- When hitting the rate limit, use the recommendation in the message (if available) to determine backoff time.
- Run embeddings sequentially, as we're most likely to hit rate limit before any other performance bottleneck. This prevents overload of rate-limited requests and log spam.
- Increase attempt count to 25.

