### PR TITLE
Add logic for ingest resumption

### DIFF
--- a/design_docs/db/atlas_search_index.jsonc
+++ b/design_docs/db/atlas_search_index.jsonc
@@ -1,7 +1,7 @@
 {
   "name": "knnTestIndex",
   "database": "docs_chat",
-  "collectionName": "content",
+  "collectionName": "embedded_content",
   "mappings": {
     "dynamic": true,
     "fields": {

--- a/ingest/src/DevCenterDataSource.ts
+++ b/ingest/src/DevCenterDataSource.ts
@@ -1,12 +1,12 @@
 import { MongoClient } from "mongodb";
-import { Page } from "chat-core";
+import { Page, logger } from "chat-core";
 import { DataSource } from "./DataSource";
 
 // This type is based on what's in the DevCenter search_content_prod collection
 export type DevCenterEntry = {
   name: string;
   description: string;
-  content: string;
+  content: string | null;
   calculated_slug: string;
 };
 
@@ -34,12 +34,23 @@ export const makeDevCenterDataSource = async ({
 
         const pages: Page[] = [];
         for await (const document of documents) {
+          if (!document.content) {
+            logger.warn(
+              `Discarding empty content document: ${document.calculated_slug}`
+            );
+            continue;
+          }
           pages.push({
             body: document.content,
             format: "md",
             sourceName: name,
             tags: [], // TODO
-            url: baseUrl + document.calculated_slug,
+            url: /^https?:\/\//.test(document.calculated_slug)
+              ? document.calculated_slug
+              : new URL(
+                  document.calculated_slug,
+                  baseUrl.replace(/\/?$/, "/")
+                ).toString(),
           });
         }
         return pages;

--- a/ingest/src/updateEmbeddedContent.ts
+++ b/ingest/src/updateEmbeddedContent.ts
@@ -101,7 +101,7 @@ export const updateEmbeddedContentForPage = async ({
 
   // Process sequentially because we're likely to hit rate limits before any
   // other performance bottleneck
-  for (const i in contentChunks) {
+  for (let i = 0; i < contentChunks.length; ++i) {
     const chunk = contentChunks[i];
     logger.info(
       `Vectorizing chunk ${i + 1}/${contentChunks.length} for ${

--- a/ingest/src/updateEmbeddedContent.ts
+++ b/ingest/src/updateEmbeddedContent.ts
@@ -48,11 +48,6 @@ export const updateEmbeddedContent = async ({
         break;
       case "created": // fallthrough
       case "updated":
-        logger.info(
-          `${
-            page.action === "created" ? "Creating" : "Updating"
-          } embedded content for ${page.sourceName}:${page.url}`
-        );
         await updateEmbeddedContentForPage({
           store: embeddedContentStore,
           page,
@@ -76,10 +71,43 @@ export const updateEmbeddedContentForPage = async ({
 }): Promise<void> => {
   const contentChunks = await chunkPage(page, chunkOptions);
 
+  // In order to resume where we left off (in case of script restart), compare
+  // the date of any existing chunks with the page updated date. If the chunks
+  // have been updated since the page was updated (and we have the expected
+  // number of chunks), assume the embedded content for that page is complete
+  // and up-to-date. To force an update, you can delete the chunks from the
+  // collection.
+  const existingContent = await store.loadEmbeddedContent({
+    page,
+  });
+  if (
+    existingContent.length !== 0 &&
+    existingContent[0].updated > page.updated &&
+    contentChunks.length === existingContent.length
+  ) {
+    logger.info(
+      `Embedded content for ${page.sourceName}:${page.url} already updated (${existingContent[0].updated}) since page update date (${page.updated}). Skipping embedding.`
+    );
+    return;
+  }
+
+  logger.info(
+    `${
+      page.action === "created" ? "Creating" : "Updating"
+    } embedded content for ${page.sourceName}:${page.url}`
+  );
+
   const embeddedContent: EmbeddedContent[] = [];
+
   // Process sequentially because we're likely to hit rate limits before any
   // other performance bottleneck
-  for (const chunk of contentChunks) {
+  for (const i in contentChunks) {
+    const chunk = contentChunks[i];
+    logger.info(
+      `Vectorizing chunk ${i + 1}/${contentChunks.length} for ${
+        page.sourceName
+      }:${page.url}`
+    );
     const { embedding } = await embed({
       text: chunk.text,
       userIp: "127.0.0.1",


### PR DESCRIPTION
Jira: N/A

## Changes

- Adds logic to resume from where you left off in the embed command
- Also logs per-chunk so you have a better idea of why the rate limit is getting hit so often

Bits & bobs:
- Handle null entries in devcenter
- Update a spec document for new collection name
