### PR TITLE
Fix URL building for devcenter paths

### DIFF
--- a/ingest/src/DevCenterDataSource.ts
+++ b/ingest/src/DevCenterDataSource.ts
@@ -48,8 +48,8 @@ export const makeDevCenterDataSource = async ({
             url: /^https?:\/\//.test(document.calculated_slug)
               ? document.calculated_slug
               : new URL(
-                  document.calculated_slug,
-                  baseUrl.replace(/\/?$/, "/")
+                  document.calculated_slug.replace(/^\/?/, ""), // Strip leading slash (if present) to not clobber baseUrl path
+                  baseUrl.replace(/\/?$/, "/") // Add trailing slash to not lose last segment of baseUrl
                 ).toString(),
           });
         }


### PR DESCRIPTION
Jira: N/A

Fixes the URL builder, which was copied from the Snooty side, but devcenter `calculated_slug` has a leading slash which, it turns out, overrides any path in the baseUrl.