### PR TITLE
(DOCSP-31304): Implement 'all' command

### DIFF
--- a/chat-core/src/DatabaseConnection.ts
+++ b/chat-core/src/DatabaseConnection.ts
@@ -56,6 +56,7 @@ export const makeDatabaseConnection = async ({
     },
 
     async updateEmbeddedContent({ page, embeddedContent }) {
+      assert(embeddedContent.length !== 0);
       embeddedContent.forEach((embeddedContent) => {
         assert(
           embeddedContent.sourceName === page.sourceName &&
@@ -74,10 +75,6 @@ export const makeDatabaseConnection = async ({
             throw new Error("EmbeddedContent deletion not acknowledged!");
           }
 
-          if (embeddedContent.length === 0) {
-            // Done
-            return;
-          }
           // Insert the embedded content for the page
           const insertResult = await embeddedContentCollection.insertMany(
             [...embeddedContent],

--- a/chat-core/src/DatabaseConnection.ts
+++ b/chat-core/src/DatabaseConnection.ts
@@ -74,6 +74,10 @@ export const makeDatabaseConnection = async ({
             throw new Error("EmbeddedContent deletion not acknowledged!");
           }
 
+          if (embeddedContent.length === 0) {
+            // Done
+            return;
+          }
           // Insert the embedded content for the page
           const insertResult = await embeddedContentCollection.insertMany(
             [...embeddedContent],

--- a/chat-core/src/Page.ts
+++ b/chat-core/src/Page.ts
@@ -49,5 +49,8 @@ export type PageStore = {
     sources?: string[];
   }): Promise<PersistedPage[]>;
 
+  /**
+    Updates or adds the given pages in the store.
+   */
   updatePages(pages: PersistedPage[]): Promise<void>;
 };

--- a/ingest/src/IngestMetaStore.ts
+++ b/ingest/src/IngestMetaStore.ts
@@ -1,0 +1,87 @@
+import { MongoClient } from "mongodb";
+
+/**
+  The ingest meta has information about ingest runs so that the script can
+  resume from a known successful run date.
+
+  If the 'since' date given to the embed command is too late, pages that were
+  updated during a failed run will not be picked up.
+
+  If too early, more pages and embeddings will be checked than necessary. The
+  embed command will not unnecessarily create new embeddings for page updates
+  that it has already created embeddings for, but it would still be wasteful to
+  have to check potentially all pages and embeddings when the date is early
+  enough. 
+ */
+export type IngestMetaStore = {
+  /**
+    The ID of the specific metadata document this store is associated with.
+    Generally there should be only one document per ingest_meta collection per
+    database.
+   */
+  readonly entryId: string;
+
+  /**
+    Returns the last successful run date for the store's entry.
+   */
+  loadLastSuccessfulRunDate(): Promise<Date | null>;
+
+  /**
+    Sets the store's entry to the current date.
+   */
+  updateLastSuccessfulRunDate(): Promise<void>;
+
+  /**
+    Closes the connection. Must be called when done.
+   */
+  close(): Promise<void>;
+};
+
+export type IngestMetaEntry = {
+  _id: string;
+  lastIngestDate: Date;
+};
+
+/**
+  Creates a connection to ingest meta collection.
+ */
+export const makeIngestMetaStore = async ({
+  connectionUri,
+  databaseName,
+  entryId,
+}: {
+  connectionUri: string;
+  databaseName: string;
+  entryId: string;
+}): Promise<IngestMetaStore> => {
+  const client = await MongoClient.connect(connectionUri);
+  const collection = client
+    .db(databaseName)
+    .collection<IngestMetaEntry>("ingest_meta");
+  return {
+    entryId,
+
+    async close() {
+      await client.close();
+    },
+    async loadLastSuccessfulRunDate() {
+      return (
+        (await collection.findOne({ _id: entryId }))?.lastIngestDate ?? null
+      );
+    },
+    async updateLastSuccessfulRunDate() {
+      await collection.updateOne(
+        {
+          _id: entryId,
+        },
+        {
+          $set: {
+            _id: entryId,
+            lastIngestDate: new Date(),
+          },
+        },
+        { upsert: true }
+      );
+    },
+  };
+};

--- a/ingest/src/commands/all.test.ts
+++ b/ingest/src/commands/all.test.ts
@@ -1,7 +1,8 @@
 import { PageStore, EmbeddedContentStore, assertEnvVars } from "chat-core";
-import { INGEST_ENV_VARS } from "../IngestEnvVars";
-import { doAllCommand, makeIngestMetaStore } from "./all";
 import { MongoClient } from "mongodb";
+import { INGEST_ENV_VARS } from "../IngestEnvVars";
+import { doAllCommand } from "./all";
+import { makeIngestMetaStore } from "../IngestMetaStore";
 
 import "dotenv/config";
 

--- a/ingest/src/commands/all.test.ts
+++ b/ingest/src/commands/all.test.ts
@@ -1,0 +1,115 @@
+import { PageStore, EmbeddedContentStore, assertEnvVars } from "chat-core";
+import { INGEST_ENV_VARS } from "../IngestEnvVars";
+import { doAllCommand, makeIngestMetaStore } from "./all";
+import { MongoClient } from "mongodb";
+
+import "dotenv/config";
+
+jest.setTimeout(1000000);
+
+describe("allCommand", () => {
+  const { MONGODB_CONNECTION_URI: connectionUri } =
+    assertEnvVars(INGEST_ENV_VARS);
+
+  const mockEmbeddedContentStore: EmbeddedContentStore = {
+    async deleteEmbeddedContent() {
+      return;
+    },
+    async findNearestNeighbors() {
+      return [];
+    },
+    async loadEmbeddedContent() {
+      return [];
+    },
+    async updateEmbeddedContent() {
+      return;
+    },
+  };
+  const mockPageStore: PageStore = {
+    async loadPages() {
+      return [];
+    },
+    async updatePages() {
+      return;
+    },
+  };
+
+  let databaseName: string;
+
+  beforeEach(async () => {
+    databaseName = `test-all-command-${Date.now()}-${Math.floor(
+      Math.random() * 10000000
+    )}`;
+  });
+
+  afterEach(async () => {
+    const client = await MongoClient.connect(connectionUri);
+    try {
+      const db = client.db(databaseName);
+      await db.dropDatabase();
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("updates the metadata with the last successful timestamp", async () => {
+    const ingestMetaStore = await makeIngestMetaStore({
+      connectionUri,
+      databaseName,
+      entryId: "all",
+    });
+    try {
+      let lastSuccessfulRunDate =
+        await ingestMetaStore.loadLastSuccessfulRunDate();
+      expect(lastSuccessfulRunDate).toBeNull();
+      await doAllCommand({
+        pageStore: mockPageStore,
+        embeddedContentStore: mockEmbeddedContentStore,
+        connectionUri,
+        databaseName,
+        async doPagesCommand() {
+          return;
+        },
+      });
+      lastSuccessfulRunDate = await ingestMetaStore.loadLastSuccessfulRunDate();
+      expect(lastSuccessfulRunDate?.getTime()).toBeGreaterThan(
+        Date.now() - 5000
+      );
+      expect(lastSuccessfulRunDate?.getTime()).toBeLessThanOrEqual(Date.now());
+    } finally {
+      await ingestMetaStore.close();
+    }
+  });
+
+  it("does not update the metadata with the last successful timestamp on failure", async () => {
+    const ingestMetaStore = await makeIngestMetaStore({
+      connectionUri,
+      databaseName,
+      entryId: "all",
+    });
+    try {
+      let lastSuccessfulRunDate =
+        await ingestMetaStore.loadLastSuccessfulRunDate();
+      expect(lastSuccessfulRunDate).toBeNull();
+      try {
+        await doAllCommand({
+          pageStore: mockPageStore,
+          embeddedContentStore: mockEmbeddedContentStore,
+          connectionUri,
+          databaseName,
+          async doPagesCommand() {
+            // Sudden failure!
+            throw new Error("Fail!");
+          },
+        });
+      } catch (e: unknown) {
+        expect((e as { message: string }).message).toBe("Fail!");
+      }
+      lastSuccessfulRunDate = await ingestMetaStore.loadLastSuccessfulRunDate();
+      // Not updated because run failed
+      expect(lastSuccessfulRunDate).toBeNull();
+    } finally {
+      await ingestMetaStore.close();
+    }
+  });
+});

--- a/ingest/src/commands/all.ts
+++ b/ingest/src/commands/all.ts
@@ -1,12 +1,155 @@
 import { CommandModule } from "yargs";
+import { doPagesCommand } from "./pages";
+import { doEmbedCommand } from "./embed";
+import {
+  makeDatabaseConnection,
+  assertEnvVars,
+  EmbeddedContentStore,
+  PageStore,
+} from "chat-core";
+import { MongoClient } from "mongodb";
+import { INGEST_ENV_VARS } from "../IngestEnvVars";
 
-const commandModule: CommandModule = {
+const commandModule: CommandModule<unknown, unknown> = {
   command: "all",
   async handler() {
-    console.log("Hello all!");
-    console.log("The time is:", new Date().toISOString());
+    const { MONGODB_CONNECTION_URI, MONGODB_DATABASE_NAME } =
+      assertEnvVars(INGEST_ENV_VARS);
+
+    const store = await makeDatabaseConnection({
+      connectionUri: MONGODB_CONNECTION_URI,
+      databaseName: MONGODB_DATABASE_NAME,
+    });
+
+    try {
+      await doAllCommand({ pageStore: store, embeddedContentStore: store });
+    } finally {
+      await store.close();
+    }
   },
-  describe: "Testing command",
+  describe: "Run 'pages' and 'embed' since last successful run",
 };
 
 export default commandModule;
+
+const doAllCommand = async ({
+  pageStore,
+  embeddedContentStore,
+}: {
+  pageStore: PageStore;
+  embeddedContentStore: EmbeddedContentStore;
+}) => {
+  const { MONGODB_CONNECTION_URI, MONGODB_DATABASE_NAME } =
+    assertEnvVars(INGEST_ENV_VARS);
+
+  const ingestMetaStore = await makeIngestMetaStore({
+    connectionUri: MONGODB_CONNECTION_URI,
+    databaseName: MONGODB_DATABASE_NAME,
+    entryId: "all",
+  });
+
+  try {
+    const lastSuccessfulRunDate =
+      await ingestMetaStore.loadLastSuccessfulRunDate();
+
+    await doPagesCommand({
+      store: pageStore,
+    });
+
+    await doEmbedCommand({
+      since: lastSuccessfulRunDate ?? new Date("2023-01-01"),
+      pageStore,
+      embeddedContentStore,
+    });
+
+    await ingestMetaStore.updateLastSuccessfulRunDate();
+  } finally {
+    await ingestMetaStore.close();
+  }
+};
+
+export type IngestMetaEntry = {
+  _id: string;
+  lastIngestDate: Date;
+};
+
+/**
+  The ingest meta has information about ingest runs so that the script can
+  resume from a known successful run date.
+
+  If the 'since' date given to the embed command is too late, pages that were
+  updated during a failed run will not be picked up.
+
+  If too early, more pages and embeddings will be checked than necessary. The
+  embed command will not unnecessarily create new embeddings for page updates
+  that it has already created embeddings for, but it would still be wasteful to
+  have to check potentially all pages and embeddings when the date is early
+  enough. 
+ */
+export type IngestMetaStore = {
+  /**
+    The ID of the specific metadata document this store is associated with.
+    Generally there should be only one document per ingest_meta collection per
+    database.
+   */
+  readonly entryId: string;
+
+  /**
+    Returns the last successful run date for the store's entry.
+   */
+  loadLastSuccessfulRunDate(): Promise<Date | null>;
+
+  /**
+    Sets the store's entry to the current date.
+   */
+  updateLastSuccessfulRunDate(): Promise<void>;
+
+  /**
+    Closes the connection. Must be called when done.
+   */
+  close(): Promise<void>;
+};
+
+/**
+  Creates a connection to ingest meta collection.
+ */
+export const makeIngestMetaStore = async ({
+  connectionUri,
+  databaseName,
+  entryId,
+}: {
+  connectionUri: string;
+  databaseName: string;
+  entryId: string;
+}): Promise<IngestMetaStore> => {
+  const client = await MongoClient.connect(connectionUri);
+  const collection = client
+    .db(databaseName)
+    .collection<IngestMetaEntry>("ingest_meta");
+  return {
+    entryId,
+
+    async close() {
+      await client.close();
+    },
+    async loadLastSuccessfulRunDate() {
+      return (
+        (await collection.findOne({ _id: entryId }))?.lastIngestDate ?? null
+      );
+    },
+    async updateLastSuccessfulRunDate() {
+      await collection.updateOne(
+        {
+          _id: entryId,
+        },
+        {
+          $set: {
+            _id: entryId,
+            lastIngestDate: new Date(),
+          },
+        },
+        { upsert: true }
+      );
+    },
+  };
+};

--- a/ingest/src/commands/all.ts
+++ b/ingest/src/commands/all.ts
@@ -8,8 +8,8 @@ import {
   PageStore,
   logger,
 } from "chat-core";
-import { MongoClient } from "mongodb";
 import { INGEST_ENV_VARS } from "../IngestEnvVars";
+import { makeIngestMetaStore } from "../IngestMetaStore";
 
 const commandModule: CommandModule<unknown, unknown> = {
   command: "all",
@@ -81,90 +81,4 @@ export const doAllCommand = async ({
   } finally {
     await ingestMetaStore.close();
   }
-};
-
-export type IngestMetaEntry = {
-  _id: string;
-  lastIngestDate: Date;
-};
-
-/**
-  The ingest meta has information about ingest runs so that the script can
-  resume from a known successful run date.
-
-  If the 'since' date given to the embed command is too late, pages that were
-  updated during a failed run will not be picked up.
-
-  If too early, more pages and embeddings will be checked than necessary. The
-  embed command will not unnecessarily create new embeddings for page updates
-  that it has already created embeddings for, but it would still be wasteful to
-  have to check potentially all pages and embeddings when the date is early
-  enough. 
- */
-export type IngestMetaStore = {
-  /**
-    The ID of the specific metadata document this store is associated with.
-    Generally there should be only one document per ingest_meta collection per
-    database.
-   */
-  readonly entryId: string;
-
-  /**
-    Returns the last successful run date for the store's entry.
-   */
-  loadLastSuccessfulRunDate(): Promise<Date | null>;
-
-  /**
-    Sets the store's entry to the current date.
-   */
-  updateLastSuccessfulRunDate(): Promise<void>;
-
-  /**
-    Closes the connection. Must be called when done.
-   */
-  close(): Promise<void>;
-};
-
-/**
-  Creates a connection to ingest meta collection.
- */
-export const makeIngestMetaStore = async ({
-  connectionUri,
-  databaseName,
-  entryId,
-}: {
-  connectionUri: string;
-  databaseName: string;
-  entryId: string;
-}): Promise<IngestMetaStore> => {
-  const client = await MongoClient.connect(connectionUri);
-  const collection = client
-    .db(databaseName)
-    .collection<IngestMetaEntry>("ingest_meta");
-  return {
-    entryId,
-
-    async close() {
-      await client.close();
-    },
-    async loadLastSuccessfulRunDate() {
-      return (
-        (await collection.findOne({ _id: entryId }))?.lastIngestDate ?? null
-      );
-    },
-    async updateLastSuccessfulRunDate() {
-      await collection.updateOne(
-        {
-          _id: entryId,
-        },
-        {
-          $set: {
-            _id: entryId,
-            lastIngestDate: new Date(),
-          },
-        },
-        { upsert: true }
-      );
-    },
-  };
 };

--- a/ingest/src/commands/all.ts
+++ b/ingest/src/commands/all.ts
@@ -6,6 +6,7 @@ import {
   assertEnvVars,
   EmbeddedContentStore,
   PageStore,
+  logger,
 } from "chat-core";
 import { MongoClient } from "mongodb";
 import { INGEST_ENV_VARS } from "../IngestEnvVars";
@@ -63,6 +64,8 @@ export const doAllCommand = async ({
     const lastSuccessfulRunDate =
       await ingestMetaStore.loadLastSuccessfulRunDate();
 
+    logger.info(`Last successful run date: ${lastSuccessfulRunDate}`);
+
     await doPagesCommand({
       store: pageStore,
     });
@@ -73,6 +76,7 @@ export const doAllCommand = async ({
       embeddedContentStore,
     });
 
+    logger.info(`Updating last successful run date`);
     await ingestMetaStore.updateLastSuccessfulRunDate();
   } finally {
     await ingestMetaStore.close();

--- a/ingest/src/commands/embed.ts
+++ b/ingest/src/commands/embed.ts
@@ -17,9 +17,21 @@ type EmbeddedContentCommandArgs = {
 const commandModule: CommandModule<unknown, EmbeddedContentCommandArgs> = {
   command: "embed",
   builder(args) {
-    return args.string("since").string("source").demandOption("since");
+    return args
+      .string("since")
+      .option("source", {
+        string: true,
+        description:
+          "A source name to load. If unspecified, loads all sources.",
+      })
+      .demandOption("since");
   },
   async handler({ since, source }) {
+    if (isNaN(Date.parse(since))) {
+      throw new Error(
+        `The value for 'since' (${since}) must be a valid JavaScript date string.`
+      );
+    }
     const { MONGODB_CONNECTION_URI, MONGODB_DATABASE_NAME } =
       assertEnvVars(INGEST_ENV_VARS);
 

--- a/ingest/src/commands/embed.ts
+++ b/ingest/src/commands/embed.ts
@@ -3,13 +3,15 @@ import {
   makeDatabaseConnection,
   assertEnvVars,
   makeOpenAiEmbedFunc,
+  EmbeddedContentStore,
+  PageStore,
 } from "chat-core";
 import { updateEmbeddedContent } from "../updateEmbeddedContent";
 import { INGEST_ENV_VARS } from "../IngestEnvVars";
 
 type EmbeddedContentCommandArgs = {
   since: string;
-  source?: string;
+  source?: string | string[];
 };
 
 const commandModule: CommandModule<unknown, EmbeddedContentCommandArgs> = {
@@ -18,45 +20,20 @@ const commandModule: CommandModule<unknown, EmbeddedContentCommandArgs> = {
     return args.string("since").string("source").demandOption("since");
   },
   async handler({ since, source }) {
-    const {
-      MONGODB_CONNECTION_URI,
-      MONGODB_DATABASE_NAME,
-      OPENAI_ENDPOINT,
-      OPENAI_API_KEY,
-      OPENAI_EMBEDDING_MODEL_VERSION,
-      OPENAI_EMBEDDING_DEPLOYMENT,
-    } = assertEnvVars(INGEST_ENV_VARS);
-
-    const embed = makeOpenAiEmbedFunc({
-      baseUrl: OPENAI_ENDPOINT,
-      apiKey: OPENAI_API_KEY,
-      apiVersion: OPENAI_EMBEDDING_MODEL_VERSION,
-      deployment: OPENAI_EMBEDDING_DEPLOYMENT,
-      backoffOptions: {
-        numOfAttempts: 25,
-        startingDelay: 1000,
-      },
-    });
+    const { MONGODB_CONNECTION_URI, MONGODB_DATABASE_NAME } =
+      assertEnvVars(INGEST_ENV_VARS);
 
     const store = await makeDatabaseConnection({
       connectionUri: MONGODB_CONNECTION_URI,
       databaseName: MONGODB_DATABASE_NAME,
     });
 
-    const sourceNames =
-      source === undefined
-        ? undefined
-        : Array.isArray(source)
-        ? source
-        : [source];
-
     try {
-      await updateEmbeddedContent({
-        since: new Date(since),
-        sourceNames,
+      await doEmbedCommand({
         pageStore: store,
         embeddedContentStore: store,
-        embed,
+        since: new Date(since),
+        source,
       });
     } finally {
       await store.close();
@@ -66,3 +43,48 @@ const commandModule: CommandModule<unknown, EmbeddedContentCommandArgs> = {
 };
 
 export default commandModule;
+
+export const doEmbedCommand = async ({
+  pageStore,
+  embeddedContentStore,
+  since,
+  source,
+}: {
+  since: Date;
+  pageStore: PageStore;
+  embeddedContentStore: EmbeddedContentStore;
+  source?: string | string[];
+}) => {
+  const {
+    OPENAI_ENDPOINT,
+    OPENAI_API_KEY,
+    OPENAI_EMBEDDING_MODEL_VERSION,
+    OPENAI_EMBEDDING_DEPLOYMENT,
+  } = assertEnvVars(INGEST_ENV_VARS);
+
+  const embed = makeOpenAiEmbedFunc({
+    baseUrl: OPENAI_ENDPOINT,
+    apiKey: OPENAI_API_KEY,
+    apiVersion: OPENAI_EMBEDDING_MODEL_VERSION,
+    deployment: OPENAI_EMBEDDING_DEPLOYMENT,
+    backoffOptions: {
+      numOfAttempts: 25,
+      startingDelay: 1000,
+    },
+  });
+
+  const sourceNames =
+    source === undefined
+      ? undefined
+      : Array.isArray(source)
+      ? source
+      : [source];
+
+  await updateEmbeddedContent({
+    since,
+    sourceNames,
+    pageStore,
+    embeddedContentStore,
+    embed,
+  });
+};


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-31304

## Changes

- Creates 'all' command that can be run from docker, etc.
- Moves actual command logic to `doCommand` external functions so I can call them from elsewhere
- Uses a meta collection to keep track of previous successful runs - deducing this from existing documents turns out to be pretty complicated and we may as well just use a very early 'since' at that point: we would look at all pages and embeddings to make sure everything is successfully updated, then update those that have not yet been updated (the embed command does resume where it left off at least, so it wouldn't just duplicate work). That said, having a meta document in the database is a pretty simple optimization.
- Bug fix: warn and gracefully handle empty chunks set (which can happen when sources return empty pages)

## Test

- Ran once locally, aborted
- Ran again, started from dawn of time (2023) due to no prior successful run
- Ran again after successful run and it correctly determined it had nothing to update
